### PR TITLE
fix: preserve paragraph structure in multi-paragraph text frames and apply terminology rules

### DIFF
--- a/ppt_translator/ppt_handler.py
+++ b/ppt_translator/ppt_handler.py
@@ -898,7 +898,7 @@ class ComplexityAnalyzer:
     def slide_has_complex_formatting(text_items: List[Dict]) -> bool:
         """Check if slide has complex formatting including bullets and indentation"""
         for item in text_items:
-            if item['type'] == 'text_frame_unified':
+            if item['type'] in ('text_frame_unified', 'text_frame_paragraph'):
                 if ComplexityAnalyzer._text_frame_has_complex_formatting(item['text_frame']):
                     return True
         return False
@@ -1137,6 +1137,15 @@ class TranslationStrategy:
             elif item_type == 'text_frame_unified':
                 text_frame = item['text_frame']
                 self.text_updater.update_text_frame(text_frame, translation, target_language)
+                return True
+            
+            elif item_type == 'text_frame_paragraph':
+                text_frame = item['text_frame']
+                para_idx = item['paragraph_index']
+                if para_idx < len(text_frame.paragraphs):
+                    paragraph = text_frame.paragraphs[para_idx]
+                    para_info = FormattingExtractor._extract_single_paragraph_info(paragraph)
+                    FormattingApplier.apply_paragraph_structure(paragraph, para_info, translation, target_language)
                 return True
                 
             elif item_type == 'direct_text':

--- a/ppt_translator/prompts.py
+++ b/ppt_translator/prompts.py
@@ -9,16 +9,40 @@ class PromptGenerator:
     """Generates translation prompts with consistent rules"""
     
     @classmethod
+    def _build_terminology_rules(cls, target_language: str) -> str:
+        """Build terminology rules string from Config if available for the target language"""
+        term_attr = f"{Config.LANGUAGE_MAP.get(target_language, '').upper().split()[0]}_TERMINOLOGY" if target_language else ""
+        # Try language-specific first (e.g., KOREAN_TERMINOLOGY), fallback to generic
+        terminology = None
+        if target_language == 'ko':
+            terminology = getattr(Config, 'KOREAN_TERMINOLOGY', None)
+        elif target_language == 'ja':
+            terminology = getattr(Config, 'JAPANESE_TERMINOLOGY', None)
+        
+        if not terminology:
+            return ""
+        
+        rules = "\n\nTERMINOLOGY (use these exact translations):\n"
+        for src, tgt in terminology.items():
+            if src == tgt:
+                rules += f"- \"{src}\" → keep as \"{tgt}\" (do not translate)\n"
+            else:
+                rules += f"- \"{src}\" → \"{tgt}\"\n"
+        return rules
+    
+    @classmethod
     def create_single_prompt(cls, target_language: str, enable_polishing: bool = True) -> str:
         """Create prompt for single text translation"""
         target_lang_name = Config.LANGUAGE_MAP.get(target_language, target_language)
+        terminology = cls._build_terminology_rules(target_language)
         return f"""Translate to {target_lang_name}. 
-CRITICAL: Provide ONLY the translation. No explanations, alternatives, context notes, or additional text."""
+CRITICAL: Provide ONLY the translation. No explanations, alternatives, context notes, or additional text.{terminology}"""
     
     @classmethod
     def create_batch_prompt(cls, target_language: str, enable_polishing: bool = True) -> str:
         """Create optimized batch translation prompt"""
         target_lang_name = Config.LANGUAGE_MAP.get(target_language, target_language)
+        terminology = cls._build_terminology_rules(target_language)
         return f"""Translate each numbered text to {target_lang_name}. 
 CRITICAL RULES:
 - Provide ONLY the translation, no explanations
@@ -26,7 +50,7 @@ CRITICAL RULES:
 - No markdown formatting (**bold**, *italic*)
 - No arrows (→) or additional text
 - Keep the same numbered format: [1] translation [2] translation [3] translation
-- Do not skip any numbers
+- Do not skip any numbers{terminology}
 
 Example:
 [1] 첫 번째 번역

--- a/ppt_translator/text_utils.py
+++ b/ppt_translator/text_utils.py
@@ -385,17 +385,39 @@ class SlideTextCollector:
                 SlideTextCollector._collect_table_texts(shape, text_items, current_path)
                 return
             
-            # Handle text frames
+            # Handle text frames - collect per-paragraph to preserve structure
             if hasattr(shape, 'text_frame') and shape.text_frame:
-                full_text = shape.text_frame.text.strip()
-                if full_text and not TextProcessor.should_skip_translation(full_text):
-                    text_items.append({
-                        'type': 'text_frame_unified',
-                        'path': f"{current_path}.text_frame",
-                        'text': full_text,
-                        'shape': shape,
-                        'text_frame': shape.text_frame
-                    })
+                tf = shape.text_frame
+                paragraphs_with_text = [
+                    (i, p) for i, p in enumerate(tf.paragraphs) if p.text.strip()
+                ]
+                if not paragraphs_with_text:
+                    return
+                # Single paragraph: use unified type for backward compatibility
+                if len(paragraphs_with_text) == 1:
+                    idx, para = paragraphs_with_text[0]
+                    text = para.text.strip()
+                    if not TextProcessor.should_skip_translation(text):
+                        text_items.append({
+                            'type': 'text_frame_unified',
+                            'path': f"{current_path}.text_frame",
+                            'text': text,
+                            'shape': shape,
+                            'text_frame': tf
+                        })
+                else:
+                    # Multiple paragraphs: collect each separately
+                    for idx, para in paragraphs_with_text:
+                        text = para.text.strip()
+                        if not TextProcessor.should_skip_translation(text):
+                            text_items.append({
+                                'type': 'text_frame_paragraph',
+                                'path': f"{current_path}.text_frame.p{idx}",
+                                'text': text,
+                                'shape': shape,
+                                'text_frame': tf,
+                                'paragraph_index': idx
+                            })
                 return
             
             # Handle shapes with direct text property
@@ -444,7 +466,7 @@ class SlideTextCollector:
             
             if item_type == 'table_cell':
                 context_parts.append(f"[{i+1}] Table Cell: {text}")
-            elif item_type == 'text_frame_unified':
+            elif item_type in ('text_frame_unified', 'text_frame_paragraph'):
                 context_parts.append(f"[{i+1}] Text Frame: {text}")
             elif item_type == 'direct_text':
                 context_parts.append(f"[{i+1}] Direct Text: {text}")


### PR DESCRIPTION
## Problem

When a text frame contains multiple paragraphs (e.g., speaker info, bullet lists, diagram labels), `shape.text_frame.text` joins all paragraphs into a single `\n`-delimited string before translation. The LLM then merges them into one sentence, losing the original paragraph structure.

### Examples of broken output (v1.0.7)

| Pattern | Original | v1.0.7 Result |
|---|---|---|
| Speaker info | `(he/him)` ↵ `Sr. SA Manager` | `(he/him) 수석 SA 매니저` (1 line) |
| Bullet list (4 items) | 4 separate lines | All merged into 1 paragraph |
| Diagram label | `MCP` ↵ `Client` | `MCP 클라이언트` (1 line) |
| Multiple questions | 2 separate questions | Merged into 1 long paragraph |

### Visual comparison (v1.0.7 left vs Patched right)

**Speaker Info:**
<img width="1920" height="540" alt="comparison_slide2" src="https://github.com/user-attachments/assets/87fc53c9-c435-41ff-a8d4-76dbd6837c44" />

**Bullet List:**
<img width="1920" height="540" alt="comparison_slide3" src="https://github.com/user-attachments/assets/c926358f-66da-4b75-ae99-0565064667e4" />

**Diagram Labels:**
<img width="1920" height="540" alt="comparison_slide4" src="https://github.com/user-attachments/assets/166377c4-ce5f-4e6a-a586-f110d55b60fe" />

**Multiple Questions:**
<img width="1920" height="540" alt="comparison_slide5" src="https://github.com/user-attachments/assets/1c6019dc-2c6f-49d5-9be2-5f7e755d5645" />

## Solution

### 1. Paragraph structure preservation (`text_utils.py`, `ppt_handler.py`)

- `SlideTextCollector` now collects each paragraph as a separate translation unit (`text_frame_paragraph` type) for multi-paragraph text frames
- Single-paragraph text frames continue to use `text_frame_unified` for backward compatibility
- `TranslationStrategy._apply_translation_to_item()` applies translations back to the exact paragraph index, preserving layout and formatting
- `ComplexityAnalyzer` recognizes the new type for formatting detection

### 2. Terminology rules in prompts (`prompts.py`)

- `Config.KOREAN_TERMINOLOGY` (and other language-specific dictionaries) were defined but never injected into prompts
- Added `_build_terminology_rules()` that generates terminology instructions from the config
- Injected into both `create_single_prompt()` and `create_batch_prompt()`
- Users can customize `KOREAN_TERMINOLOGY` in `config.py` to control which terms are kept in original language or translated to specific terms

## Testing

Tested with a purpose-built sample presentation containing all 4 broken patterns, plus real-world presentations (55-slide Physical AI deck, 30-slide Kiro MCP deck). All paragraph structures preserved correctly after the patch.

Signed-off-by: Chihoon Jeon